### PR TITLE
Closes #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-circuit",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "description": "A Circuit adapter for hubot",
   "main": "src/circuit.coffee",
   "scripts": {
@@ -16,6 +16,10 @@
   ],
   "engines": {
     "node": ">= 4.8.4"
+  },
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/circuit/hubot-circuit.git"
   },
   "dependencies": {
     "body-parser": "^1.17.1",

--- a/src/circuit.coffee
+++ b/src/circuit.coffee
@@ -97,7 +97,7 @@ class CircuitBot extends Adapter
         auth:
           user: @conf.clientId
           pass: @conf.clientSecret
-        body: JSON.stringify
+        form:
           grant_type : 'client_credentials',
           client_id  : @conf.clientId,
           client_secret : @conf.clientSecret,
@@ -107,7 +107,7 @@ class CircuitBot extends Adapter
       # Get access token
       request.post options, (err, res, body) =>
 
-        if err or res.statusCode > 400
+        if err or res.statusCode >= 400
           @log.error "error: #{err}, statusCode: #{res.statusCode}, #{body}"
           reject(err)
           return
@@ -129,7 +129,7 @@ class CircuitBot extends Adapter
 
       request.get uri: URL.GET_PROFILE, (err, res, body) =>
 
-        if err or res.statusCode > 400
+        if err or res.statusCode >= 400
           @log.error "error: #{err}, statusCode: #{res.statusCode}, #{body}"
           reject(err)
           return
@@ -162,7 +162,7 @@ class CircuitBot extends Adapter
       @log.info 'sending http to:', url
       request.get url, (err, res, body) =>
 
-        if err or res.statusCode > 400
+        if err or res.statusCode >= 400
           @log.error "error: #{err}, statusCode: #{res.statusCode}, #{body}"
           reject(err)
           return
@@ -187,7 +187,7 @@ class CircuitBot extends Adapter
       # Register webhooks
       request.post options, (err, res, body) =>
 
-        if err or res.statusCode > 400
+        if err or res.statusCode >= 400
           @log.error "error: #{err}, statusCode: #{res.statusCode}, #{body}"
           reject(err)
           return
@@ -284,7 +284,7 @@ class CircuitBot extends Adapter
     @log.info 'sending http to:', options.uri
     request.post options, (err, res, body) =>
 
-      if err or res.statusCode > 400
+      if err or res.statusCode >= 400
         @log.error "error: #{err}, statusCode: #{res.statusCode}, #{body}"
         return
 

--- a/test/circuit.spec.coffee
+++ b/test/circuit.spec.coffee
@@ -189,7 +189,7 @@ describe 'Circuit adapter', ->
                 user: @circuitBot.conf.clientId
                 pass: @circuitBot.conf.clientSecret
               uri: '/oauth/token'
-              body: JSON.stringify
+              form:
                 grant_type: 'client_credentials'
                 client_id: @circuitBot.conf.clientId
                 client_secret: @circuitBot.conf.clientSecret


### PR DESCRIPTION
- Request to /oauth/token endpoint sends form-data instead of json
- 400 requests are handled as errors